### PR TITLE
More flexible /webhooks path plus GH workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: Build
+
+on:
+  push:
+
+jobs:
+  build:
+    name: Yarn Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # sets ref to the last commit hash
+
+      - name: Install Node and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "yarn"
+
+      - name: Install
+        run: make install
+
+      - name: Build
+        run: make build
+
+      - name: Test
+        run: make test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,24 @@
+name: Publish Docker
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+jobs:
+  build:
+    name: Yarn Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # sets ref to the last commit hash
+
+      - name: Install Node and Yarn
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+          cache: "yarn"
+
+      - name: Docker
+        run: make release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.0.2] - 2021-10-21
+### Added
+* GitHub workflows
+
+### Changed
+
+* `/webhook/transfer` path changed to `/webhooks`
+
+## [1.0.1] - 2021-10-20
+### Added
+* `APP_CONFIG_SECRETS` synonym for `CONFIG_FILE_PATH`
 
 ## [1.0.0] - 2021-10-28
-
-Initial release.
+* Initial release

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,6 @@ COPY ./yarn.lock .
 RUN yarn install --frozen-lockfile
 RUN yarn build
 
-# TODO: Use a secrets management solution to inject the configuration file at ./config/config.yml
-
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
   CMD curl -f http://localhost:${PORT:-8080}/ || exit 1
 

--- a/Makefile
+++ b/Makefile
@@ -3,21 +3,21 @@ COMMIT_HASH :=$(shell git rev-parse --short HEAD)
 TAG_VERSION := $(shell git describe --tags --abbrev=0)
 
 .PHONY: build test docker clean
-build:
-	yarn run build
-
-run:
-	docker run --read-only \
-		-p 8080:8080 moovfinancial/slack-integration:$(VERSION)
+clean:
+	rm -rf node_modules
 
 install:
 	yarn install --frozen-lockfile
 
+build:
+	yarn run build
+
 test:
 	yarn run test
 
-clean:
-	rm -rf node_modules
+run:
+	docker run --read-only \
+		-p 8080:8080 moovfinancial/slack-integration:$(VERSION)
 
 release: clean install build test
 ifeq ($(VERSION),$(TAG_VERSION))

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ You'll need a Slack app to run inside your workspace and listen for notification
 
 1. Navigate to https://dashboard.moov.io > Developers > Webhooks.
 2. Create a new webhook.
-3. Set the URL to `https://<your publicaly addressable host>/webhook/transfer`.
+3. Set the URL to `https://<your publicaly addressable host>/webhooks`.
 4. Select the `transfer.created` and `transfer.updated` events. If you fork and customize this app, be sure to subscribe to any additional events you'd like to receive.
 5. Copy the **webhook signing secret** to the `moov` section in `./config/config.yml`.
 

--- a/dist/configuration.js
+++ b/dist/configuration.js
@@ -42,7 +42,9 @@ exports.active = active;
 async function loadFromFile() {
     let config = {};
     try {
-        const configPath = process.env.CONFIG_FILE_PATH || path.join(process.cwd(), "/config/config.yml");
+        const configPath = process.env.CONFIG_FILE_PATH ||
+            process.env.APP_CONFIG_SECRETS ||
+            path.join(process.cwd(), "/config/config.yml");
         const contents = await fs.readFile(configPath, "utf8");
         config = yaml.parse(contents);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-integration",
-  "version": "v1.0.1",
+  "version": "v1.0.2",
   "description": "Get Moov transfer notifications in Slack",
   "main": "dist/index.js",
   "repository": "https://github.com/moov-io/slack-integration",

--- a/src/application.ts
+++ b/src/application.ts
@@ -16,7 +16,7 @@ export async function start(config: Configuration) {
   receiver.router.use(express.json());
   receiver.router.use(express.urlencoded({ extended: true }));
 
-  receiver.router.post("/webhook/transfer", handleWebhookEvent);
+  receiver.router.post("/webhooks", handleWebhookEvent);
   receiver.router.get("/ping", async (_, res) => res.sendStatus(200));
 
   await application.start(config.port);


### PR DESCRIPTION
Added
- GitHub actions

Changed
- `/webhook/transfers` to `/webhooks` since it handles any event
