### PR TITLE
Update how destination data is created

### DIFF
--- a/dist/services/message.js
+++ b/dist/services/message.js
@@ -45,6 +45,7 @@ function transferMessage(type, transfer) {
 }
 exports.transferMessage = transferMessage;
 function transferDetails(transfer) {
+    var _a, _b, _c;
     const amount = +transfer.amount.value / 100;
     const status = transfer.status;
     const source = transfer.source.account.displayName;
@@ -54,10 +55,25 @@ function transferDetails(transfer) {
     const sourceBankAccountLastNumber = transfer.source.bankAccount.lastFourAccountNumber;
     const destination = transfer.destination.account.displayName;
     const destinationEmail = transfer.destination.account.email;
-    const destinationBankAccountName = transfer.destination.bankAccount.bankName;
-    const destinationBankAccountType = transfer.destination.bankAccount.bankAccountType;
-    const destinationBankAccountLastNumber = transfer.destination.bankAccount.lastFourAccountNumber;
-    const header = status === "pending" ? "ACH transfer created" : ":tada:  ACH transfer complete";
+    let header = "";
+    switch (status) {
+        case "pending":
+            header = "ACH transfer created";
+            break;
+        case "failed":
+            header = ":exclamation: ACH transfer failed";
+            break;
+        default:
+            header = ":tada: ACH transfer complete";
+            break;
+    }
+    let destinationDetails = "Moov wallet";
+    if (transfer.destination.bankAccount) {
+        destinationDetails = ((_a = transfer.destination.bankAccount) === null || _a === void 0 ? void 0 : _a.bankName) + "\n" +
+            ((_b = transfer.destination.bankAccount) === null || _b === void 0 ? void 0 : _b.bankAccountType) +
+            " • " +
+            ((_c = transfer.destination.bankAccount) === null || _c === void 0 ? void 0 : _c.lastFourAccountNumber);
+    }
     return {
         type: "modal",
         title: {
@@ -113,11 +129,7 @@ function transferDetails(transfer) {
                     },
                     {
                         type: "mrkdwn",
-                        text: destinationBankAccountName +
-                            "\n" +
-                            destinationBankAccountType +
-                            " • " +
-                            destinationBankAccountLastNumber,
+                        text: destinationDetails,
                     },
                 ],
             },

--- a/src/services/message.ts
+++ b/src/services/message.ts
@@ -55,10 +55,28 @@ export function transferDetails(transfer: any): View {
   const sourceBankAccountLastNumber = transfer.source.bankAccount.lastFourAccountNumber;
   const destination = transfer.destination.account.displayName;
   const destinationEmail = transfer.destination.account.email;
-  const destinationBankAccountName = transfer.destination.bankAccount.bankName;
-  const destinationBankAccountType = transfer.destination.bankAccount.bankAccountType;
-  const destinationBankAccountLastNumber = transfer.destination.bankAccount.lastFourAccountNumber;
-  const header = status === "pending" ? "ACH transfer created" : ":tada:  ACH transfer complete";
+
+  let header: string = "";
+  switch(status) {
+    case "pending":
+      header = "ACH transfer created";
+      break;
+    case "failed":
+      header = ":exclamation: ACH transfer failed";
+      break;
+    default:
+      header = ":tada: ACH transfer complete"
+      break;
+  }
+
+  let destinationDetails: string = "Moov wallet";
+
+  if (transfer.destination.bankAccount) {
+    destinationDetails = transfer.destination.bankAccount?.bankName + "\n" +
+    transfer.destination.bankAccount?.bankAccountType +
+    " • " +
+    transfer.destination.bankAccount?.lastFourAccountNumber;
+  }
 
   return {
     type: "modal",
@@ -116,12 +134,7 @@ export function transferDetails(transfer: any): View {
           },
           {
             type: "mrkdwn",
-            text:
-              destinationBankAccountName +
-              "\n" +
-              destinationBankAccountType +
-              " • " +
-              destinationBankAccountLastNumber,
+            text: destinationDetails,
           },
         ],
       },


### PR DESCRIPTION
The previous code assumed that every transfer had a bank as a destination.

This code adds a simple condition to show "Moov wallet" when no bank is involved. Josh requested it not to show the wallet ID.

My test process was using the transfer collection from Postman.

The bank-to-bank transfer generates a `destination` object with
```yaml
  destination: {
    paymentMethodID: '8e872a52-aaaf-43e1-b608-714fa610cd30',
    paymentMethodType: 'ach-credit-standard',
    account: {
      accountID: 'a3cf6145-3f9a-423c-93cc-f48c736a7bd3',
      email: 'amanda@classbooker.dev',
      displayName: 'Amanda Yang'
    },
    bankAccount: {
      bankAccountID: '4948d7c5-48c7-478f-9ee5-1b26781fd85c',
      fingerprint: 'dbc55cac28891eb9ed3b43a9320b1af634f395a90d9bf968557d850bcb54b4f6',
      status: 'verified',
      holderName: 'Amanda Yang',
      holderType: 'individual',
      bankName: 'VERIDIAN CREDIT UNION',
      bankAccountType: 'savings',
      routingNumber: '273976369',
      lastFourAccountNumber: '4322'
    }
  }
```

Other transfers:
```yaml
  destination: {
    paymentMethodID: '31d878e2-b2b4-4553-b954-bbb6f95e10d2',
    paymentMethodType: 'moov-wallet',
    account: {
      accountID: 'a3cf6145-3f9a-423c-93cc-f48c736a7bd3',
      email: 'amanda@classbooker.dev',
      displayName: 'Amanda Yang'
    },
    wallet: { walletID: '2aad8a56-e28c-461b-beab-1747143f22bb' }
  }
```