### PR TITLE
slack-integration version/tag mismatch fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-integration",
-  "version": "v1.0.7",
+  "version": "v1.0.8",
   "description": "Get Moov transfer notifications in Slack",
   "main": "dist/index.js",
   "repository": "https://github.com/moov-io/slack-integration",


### PR DESCRIPTION
Daniel Gerep made some changes and pushed tag version `v1.0.8` after his PR was merged, but the `package.json` version update was missed, so the Docker image was never created.  I've deleted the `v1.0.8` tag and once this is merged will re-create that tag

For reference (errored, but shows green 🤔 ):  https://github.com/moovfinancial/slack-integration/runs/6429126775?check_suite_focus=true